### PR TITLE
Fixes for `predict_parts` explanations

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,14 @@
 # survex (development)
 
-* fix invalid color palette order in plot feature importance
-* fix predict_parts survshap running out of memory with more than 16 variables ([#25](https://github.com/ModelOriented/survex/issues/25))
+* fixed invalid color palette order in plot feature importance
+* fixed predict_parts survshap running out of memory with more than 16 variables ([#25](https://github.com/ModelOriented/survex/issues/25))
+* added `max_vars` parameter for predict_parts explanations ([#27](https://github.com/ModelOriented/survex/issues/27))
+* set `max_vars` to 7 for every method  
+* refactored survshap code ([#29](https://github.com/ModelOriented/survex/issues/29), [#30](https://github.com/ModelOriented/survex/issues/30), [#43](https://github.com/ModelOriented/survex/issues/43))
+* fixed survshap error when target columns named different than time and status ([#44](https://github.com/ModelOriented/survex/issues/44))
+* fixed survlime error when all variables are categorical ([#46](https://github.com/ModelOriented/survex/issues/46))
+* fixed subtitles in feature importance plots ([#11](https://github.com/ModelOriented/survex/issues/11))
+
 
 # survex 0.2.2
 

--- a/R/plot_feature_importance.R
+++ b/R/plot_feature_importance.R
@@ -42,7 +42,7 @@
 #' }
 #' @export
 plot.feature_importance_explainer <- function(x, ..., max_vars = NULL, show_boxplots = TRUE, bar_width = 10,
-                                              desc_sorting = TRUE, title = "Feature Importance", subtitle = NULL) {
+                                              desc_sorting = TRUE, title = "Feature Importance", subtitle = "default") {
 
     if (!is.logical(desc_sorting)) {
         stop("desc_sorting is not logical")
@@ -103,7 +103,7 @@ plot.feature_importance_explainer <- function(x, ..., max_vars = NULL, show_boxp
     nlabels <- length(unique(bestFits$label))
 
     # extract labels for plot's subtitle
-    if (is.null(subtitle)) {
+    if (!is.null(subtitle) && subtitle == "default"){
         glm_labels <- paste0(unique(ext_expl_df$label), collapse = ", ")
         subtitle <- paste0("created for the ", glm_labels, " model")
     }

--- a/R/plot_feature_importance.R
+++ b/R/plot_feature_importance.R
@@ -12,7 +12,7 @@
 #'
 #' @param x a feature importance explainer produced with the \code{feature_importance()} function
 #' @param ... other explainers that shall be plotted together
-#' @param max_vars maximum number of variables that shall be presented for for each model.
+#' @param max_vars maximum number of variables that shall be presented for for each model
 #' By default \code{NULL} what means all variables
 #' @param show_boxplots logical if \code{TRUE} (default) boxplot will be plotted to show permutation data.
 #' @param bar_width width of bars. By default \code{10}

--- a/R/plot_predict_parts_survival.R
+++ b/R/plot_predict_parts_survival.R
@@ -16,6 +16,7 @@
 #' * `...` - additional objects of class `surv_shap` to be plotted together
 #' * `title` - character, title of the plot
 #' * `subtitle` - character, subtitle of the plot, `'default'` automatically generates "created for XXX, YYY models", where XXX and YYY are the explainer labels
+#' * `max_vars` - maximum number of variables to be plotted (least important variables are ignored)
 #' * `colors` - character vector containing the colors to be used for plotting variables (containing either hex codes "#FF69B4", or names "blue")
 #'
 #' ## `plot.surv_lime`
@@ -26,6 +27,7 @@
 #' * `...` -  other parameters currently ignored
 #' * `title` -  character, title of the plot
 #' * `subtitle` -  character, subtitle of the plot, `'default'` automatically generates "created for XXX, YYY models", where XXX and YYY are the explainer labels
+#' * `max_vars` - maximum number of variables to be plotted (least important variables are ignored)
 #' * `colors` -  character vector containing the colors to be used for plotting variables (containing either hex codes "#FF69B4", or names "blue")
 #'
 #' @family functions for plotting 'predict_parts_survival' objects

--- a/R/plot_surv_feature_importance.R
+++ b/R/plot_surv_feature_importance.R
@@ -35,7 +35,7 @@
 plot.surv_feature_importance <- function(x, ...,
                                          title = "Time-dependent feature importance",
                                          subtitle = "default",
-                                         max_vars = 6,
+                                         max_vars = 7,
                                          colors = NULL) {
 
     df_list <- c(list(x), list(...))

--- a/R/plot_surv_lime.R
+++ b/R/plot_surv_lime.R
@@ -37,15 +37,13 @@ plot.surv_lime <- function(x,
     if (!type %in% c("coefficients", "local_importance"))
         stop("Type should be one of `coefficients`, `local_importance`")
 
-    x$beta <- x$result
-
-
+    local_importance <- as.numeric(x$result * x$variable_values)
     df <- data.frame(variable_names = names(x$variable_values),
-                     variable_values = x$variable_values,
-                     beta = x$beta,
-                     sign_beta = as.factor(sign(x$result)),
-                     sign_local_importance = as.factor(sign(x$beta * x$variable_values)),
-                     local_importance = x$beta * x$variable_values)
+                     variable_values = as.numeric(x$variable_values),
+                     beta = as.numeric(x$result),
+                     sign_beta = sign(as.numeric(x$result)),
+                     sign_local_importance = as.factor(sign(local_importance)),
+                     local_importance = local_importance)
 
     if (!is.null(subtitle) && subtitle == "default") {
         subtitle <- paste0("created for the ", attr(x, "label"), " model")

--- a/R/plot_surv_lime.R
+++ b/R/plot_surv_lime.R
@@ -58,7 +58,7 @@ plot.surv_lime <- function(x,
         pl <- with(df, {
         ggplot(data = df, aes(x = beta, y = reorder(variable_names, beta, abs), fill = sign_beta)) +
             geom_col() +
-            scale_fill_manual("", values = c("#f05a71", "#8bdcbe"))
+            scale_fill_manual("", values = c("-1"="#f05a71", "0"="#ffffff", "1"="#8bdcbe"))
         })
     }
 
@@ -71,7 +71,7 @@ plot.surv_lime <- function(x,
 
             ggplot(data = df, aes(x = local_importance, y = reorder(variable_names, local_importance, abs), fill = sign_local_importance)) +
             geom_col() +
-            scale_fill_manual("", values = c("#f05a71", "#ffffff", "#8bdcbe"))
+            scale_fill_manual("", values = c("-1"="#f05a71", "0"="#ffffff", "1"="#8bdcbe"))
 
         })
     }

--- a/R/plot_surv_lime.R
+++ b/R/plot_surv_lime.R
@@ -43,7 +43,7 @@ plot.surv_lime <- function(x,
     df <- data.frame(variable_names = names(x$variable_values),
                      variable_values = as.numeric(x$variable_values),
                      beta = as.numeric(x$result),
-                     sign_beta = sign(as.numeric(x$result)),
+                     sign_beta = as.factor(sign(as.numeric(x$result))),
                      sign_local_importance = as.factor(sign(local_importance)),
                      local_importance = local_importance)
 

--- a/R/plot_surv_lime.R
+++ b/R/plot_surv_lime.R
@@ -9,6 +9,7 @@
 #' @param ... other parameters currently ignored
 #' @param title character, title of the plot
 #' @param subtitle character, subtitle of the plot, `'default'` automatically generates "created for XXX, YYY models", where XXX and YYY are the explainer labels
+#' @param max_vars maximum number of variables to be plotted (least important variables are ignored)
 #' @param colors character vector containing the colors to be used for plotting variables (containing either hex codes "#FF69B4", or names "blue")
 #'
 #' @return An object of the class `ggplot`.
@@ -33,6 +34,7 @@ plot.surv_lime <- function(x,
                            ...,
                            title = "SurvLIME",
                            subtitle = "default",
+                           max_vars = 7,
                            colors = NULL) {
     if (!type %in% c("coefficients", "local_importance"))
         stop("Type should be one of `coefficients`, `local_importance`")
@@ -52,6 +54,7 @@ plot.surv_lime <- function(x,
     if (type == "coefficients") {
         x_lab <- "SurvLIME coefficients"
         y_lab <- ""
+        df <- df[head(order(abs(df$beta), decreasing=TRUE), max_vars),]
         pl <- with(df, {
         ggplot(data = df, aes(x = beta, y = reorder(variable_names, beta, abs), fill = sign_beta)) +
             geom_col() +
@@ -63,6 +66,7 @@ plot.surv_lime <- function(x,
     if (type == "local_importance") {
         x_lab <- "SurvLIME local importance"
         y_lab <- ""
+        df <- df[head(order(abs(df$local_importance), decreasing=TRUE), max_vars),]
         pl <- with(df,{
 
             ggplot(data = df, aes(x = local_importance, y = reorder(variable_names, local_importance, abs), fill = sign_local_importance)) +

--- a/R/plot_surv_shap.R
+++ b/R/plot_surv_shap.R
@@ -7,6 +7,7 @@
 #' @param ... additional objects of class `surv_shap` to be plotted together
 #' @param title character, title of the plot
 #' @param subtitle character, subtitle of the plot, `'default'` automatically generates "created for XXX, YYY models", where XXX and YYY are the explainer labels
+#' @param max_vars maximum number of variables to be plotted (least important variables are ignored)
 #' @param colors character vector containing the colors to be used for plotting variables (containing either hex codes "#FF69B4", or names "blue")
 #'
 #' @return An object of the class `ggplot`.

--- a/R/plot_surv_shap.R
+++ b/R/plot_surv_shap.R
@@ -30,13 +30,15 @@ plot.surv_shap <- function(x,
                            ...,
                            title = "SurvSHAP(t)",
                            subtitle = "default",
+                           max_vars = 7,
                            colors = NULL) {
 
     dfl <- c(list(x), list(...))
 
     long_df <- lapply(dfl, function(x) {
         label <- attr(x, "label")
-        sv <- x$result
+        cols <- head(order(x$aggregate, decreasing = TRUE), max_vars)
+        sv <- x$result[,cols]
         times <- x$eval_times
         transposed <- as.data.frame(cbind(times = times, sv))
         rownames(transposed) <- NULL

--- a/R/plot_surv_shap.R
+++ b/R/plot_surv_shap.R
@@ -37,7 +37,7 @@ plot.surv_shap <- function(x,
 
     long_df <- lapply(dfl, function(x) {
         label <- attr(x, "label")
-        cols <- head(order(x$aggregate, decreasing = TRUE), max_vars)
+        cols <- sort(head(order(x$aggregate, decreasing = TRUE), max_vars))
         sv <- x$result[,cols]
         times <- x$eval_times
         transposed <- as.data.frame(cbind(times = times, sv))

--- a/R/predict_parts.R
+++ b/R/predict_parts.R
@@ -16,7 +16,7 @@
 #'
 #' There are additional parameters that are passed to internal functions
 #'
-#' * for `surv_lime`
+#' * for `survlime`
 #'     * `N` -  a positive integer, number of observations generated in the neighbourhood
 #'     * `distance_metric` -  character, name of the distance metric to be used, only `"euclidean"` is implemented
 #'     * `kernel_width` -  a numeric, parameter used for calculating weights, by default it's `sqrt(ncol(data)*0.75)`
@@ -25,7 +25,7 @@
 #'     * `max_iter` -  a numeric, maximal number of iteration for the optimization problem
 #'     * `categorical_variables` -  character vector, names of variables that should be treated as categories (factors are included by default)
 #'     * `k` -  a small positive number > 1, added to chf before taking log, so that weigths aren't negative
-#' * for `surv_shap`
+#' * for `survshap`
 #'     * `timestamps` -  a numeric vector, time points at which the survival function will be evaluated
 #'     * `y_true` -  a two element numeric vector or matrix of one row and two columns, the first element being the true observed time and the second the status of the observation, used for plotting
 #'     * `calculation_method` -  a character, only `"kernel"` is implemented for now.

--- a/R/predict_parts.R
+++ b/R/predict_parts.R
@@ -32,7 +32,7 @@
 #'     * `aggregation_method` -  a character, either `"mean_absolute"` or `"integral"`, `"max_absolute"`, `"sum_of_squares"`
 #'
 #' @section References:
-#' - \[1\] Krzyziński, Mateusz, et al. ["SurvSHAP(t): Time-dependent explanations of machine learning survival models."](https://arxiv.org/abs/2208.11080) arXiv preprint arXiv:2208.11080 (2022).
+#' - \[1\] Krzyziński, Mateusz, et al. ["SurvSHAP(t): Time-dependent explanations of machine learning survival models."](https://www.sciencedirect.com/science/article/pii/S0950705122013302) Knowledge-Based Systems 262 (2023): 110234
 #' - \[2\] Kovalev, Maxim S., et al. ["SurvLIME: A method for explaining machine learning survival models."](https://www.sciencedirect.com/science/article/pii/S0950705120304044?casa_token=6e9cyk_ji3AAAAAA:tbqo33MsZvNC9nrSGabZdLfPtZTsvsvZTHYQCM2aEhumLI5D46U7ovhr37EaYUhmKZrw45JzDhg) Knowledge-Based Systems 203 (2020): 106164.
 #'
 #' @examples

--- a/R/surv_lime.R
+++ b/R/surv_lime.R
@@ -32,6 +32,9 @@ surv_lime <- function(explainer, new_observation,
                       k = 1 + 1e-4) {
 
     test_explainer(explainer, "surv_lime", has_data = TRUE, has_y = TRUE, has_chf = TRUE)
+    new_observation <- new_observation[, colnames(new_observation) %in% colnames(explainer$data)]
+    if (ncol(explainer$data) != ncol(new_observation)) stop("New observation and data have different number of columns (variables)")
+
     predicted_sf <- explainer$predict_survival_function(explainer$model, new_observation, explainer$times)
 
     neighbourhood <- generate_neighbourhood(explainer$data,

--- a/R/surv_shap.R
+++ b/R/surv_shap.R
@@ -28,11 +28,6 @@ surv_shap <- function(explainer,
                       exact = FALSE
 ) {
     test_explainer(explainer, "surv_shap", has_data = TRUE, has_y = TRUE, has_survival = TRUE)
-    new_observation <- new_observation[, !colnames(new_observation) %in% colnames(explainer$y)]
-    if (ncol(explainer$data) != ncol(new_observation)) stop("New observation and data have different number of columns(variables)")
-
-    event_inds <- explainer$y[, 2]
-    event_times <- explainer$y[, 1]
 
     if (!is.null(y_true)) {
         if (is.matrix(y_true)) {
@@ -81,7 +76,7 @@ shap_kernel <- function(explainer, new_observation, aggregation_method,  ...) {
 
     ret <- list()
     ret$eval_times <- timestamps
-    ret$result <- t(shap_values)
+    ret$result <- data.frame(t(shap_values))
     ret$variable_values <- new_observation
 
     return(ret)

--- a/R/surv_shap.R
+++ b/R/surv_shap.R
@@ -13,7 +13,7 @@
 #' @return A list, containing the calculated SurvSHAP(t) results in the `result` field
 #'
 #' @section References:
-#' - \[1\] Krzyziński, Mateusz, et al. ["SurvSHAP(t): Time-dependent explanations of machine learning survival models."](https://arxiv.org/abs/2208.11080) arXiv preprint arXiv:2208.11080 (2022).
+#' - \[1\] Krzyziński, Mateusz, et al. ["SurvSHAP(t): Time-dependent explanations of machine learning survival models."](https://www.sciencedirect.com/science/article/pii/S0950705122013302) Knowledge-Based Systems 262 (2023): 110234
 #'
 #' @keywords internal
 surv_shap <- function(explainer,

--- a/R/surv_shap.R
+++ b/R/surv_shap.R
@@ -28,6 +28,7 @@ surv_shap <- function(explainer,
                       exact = FALSE
 ) {
     test_explainer(explainer, "surv_shap", has_data = TRUE, has_y = TRUE, has_survival = TRUE)
+    new_observation <- new_observation[, colnames(new_observation) %in% colnames(explainer$data)]
 
     if (!is.null(y_true)) {
         if (is.matrix(y_true)) {
@@ -54,10 +55,7 @@ surv_shap <- function(explainer,
 
 shap_kernel <- function(explainer, new_observation, aggregation_method,  ...) {
 
-
     timestamps <- explainer$times
-
-
     p <- ncol(explainer$data)
 
     target_sf <- explainer$predict_survival_function(explainer$model, new_observation, timestamps)
@@ -72,7 +70,6 @@ shap_kernel <- function(explainer, new_observation, aggregation_method,  ...) {
 
     shap_values <- as.data.frame(shap_values, row.names = colnames(explainer$data))
     colnames(shap_values) <- paste("t=", timestamps, sep = "")
-
 
     ret <- list()
     ret$eval_times <- timestamps

--- a/R/surv_shap.R
+++ b/R/surv_shap.R
@@ -29,6 +29,7 @@ surv_shap <- function(explainer,
 ) {
     test_explainer(explainer, "surv_shap", has_data = TRUE, has_y = TRUE, has_survival = TRUE)
     new_observation <- new_observation[, colnames(new_observation) %in% colnames(explainer$data)]
+    if (ncol(explainer$data) != ncol(new_observation)) stop("New observation and data have different number of columns(variables)")
 
     if (!is.null(y_true)) {
         if (is.matrix(y_true)) {

--- a/R/surv_shap.R
+++ b/R/surv_shap.R
@@ -29,7 +29,7 @@ surv_shap <- function(explainer,
 ) {
     test_explainer(explainer, "surv_shap", has_data = TRUE, has_y = TRUE, has_survival = TRUE)
     new_observation <- new_observation[, colnames(new_observation) %in% colnames(explainer$data)]
-    if (ncol(explainer$data) != ncol(new_observation)) stop("New observation and data have different number of columns(variables)")
+    if (ncol(explainer$data) != ncol(new_observation)) stop("New observation and data have different number of columns (variables)")
 
     if (!is.null(y_true)) {
         if (is.matrix(y_true)) {

--- a/man/plot.feature_importance_explainer.Rd
+++ b/man/plot.feature_importance_explainer.Rd
@@ -12,7 +12,7 @@
   bar_width = 10,
   desc_sorting = TRUE,
   title = "Feature Importance",
-  subtitle = NULL
+  subtitle = "default"
 )
 }
 \arguments{

--- a/man/plot.feature_importance_explainer.Rd
+++ b/man/plot.feature_importance_explainer.Rd
@@ -20,7 +20,7 @@
 
 \item{...}{other explainers that shall be plotted together}
 
-\item{max_vars}{maximum number of variables that shall be presented for for each model.
+\item{max_vars}{maximum number of variables that shall be presented for for each model
 By default \code{NULL} what means all variables}
 
 \item{show_boxplots}{logical if \code{TRUE} (default) boxplot will be plotted to show permutation data.}

--- a/man/plot.predict_parts_survival.Rd
+++ b/man/plot.predict_parts_survival.Rd
@@ -26,6 +26,7 @@ for survival models created using the \code{predict_parts()} function.
 \item \code{...} - additional objects of class \code{surv_shap} to be plotted together
 \item \code{title} - character, title of the plot
 \item \code{subtitle} - character, subtitle of the plot, \code{'default'} automatically generates "created for XXX, YYY models", where XXX and YYY are the explainer labels
+\item \code{max_vars} - maximum number of variables to be plotted (least important variables are ignored)
 \item \code{colors} - character vector containing the colors to be used for plotting variables (containing either hex codes "#FF69B4", or names "blue")
 }
 }
@@ -38,6 +39,7 @@ for survival models created using the \code{predict_parts()} function.
 \item \code{...} -  other parameters currently ignored
 \item \code{title} -  character, title of the plot
 \item \code{subtitle} -  character, subtitle of the plot, \code{'default'} automatically generates "created for XXX, YYY models", where XXX and YYY are the explainer labels
+\item \code{max_vars} - maximum number of variables to be plotted (least important variables are ignored)
 \item \code{colors} -  character vector containing the colors to be used for plotting variables (containing either hex codes "#FF69B4", or names "blue")
 }
 }

--- a/man/plot.surv_feature_importance.Rd
+++ b/man/plot.surv_feature_importance.Rd
@@ -9,7 +9,7 @@
   ...,
   title = "Time-dependent feature importance",
   subtitle = "default",
-  max_vars = 6,
+  max_vars = 7,
   colors = NULL
 )
 }

--- a/man/plot.surv_lime.Rd
+++ b/man/plot.surv_lime.Rd
@@ -11,6 +11,7 @@
   ...,
   title = "SurvLIME",
   subtitle = "default",
+  max_vars = 7,
   colors = NULL
 )
 }
@@ -26,6 +27,8 @@
 \item{title}{character, title of the plot}
 
 \item{subtitle}{character, subtitle of the plot, \code{'default'} automatically generates "created for XXX, YYY models", where XXX and YYY are the explainer labels}
+
+\item{max_vars}{maximum number of variables to be plotted (least important variables are ignored)}
 
 \item{colors}{character vector containing the colors to be used for plotting variables (containing either hex codes "#FF69B4", or names "blue")}
 }

--- a/man/plot.surv_shap.Rd
+++ b/man/plot.surv_shap.Rd
@@ -22,6 +22,8 @@
 
 \item{subtitle}{character, subtitle of the plot, \code{'default'} automatically generates "created for XXX, YYY models", where XXX and YYY are the explainer labels}
 
+\item{max_vars}{maximum number of variables to be plotted (least important variables are ignored)}
+
 \item{colors}{character vector containing the colors to be used for plotting variables (containing either hex codes "#FF69B4", or names "blue")}
 }
 \value{

--- a/man/plot.surv_shap.Rd
+++ b/man/plot.surv_shap.Rd
@@ -4,7 +4,14 @@
 \alias{plot.surv_shap}
 \title{Plot SurvSHAP(t) Explanations for Survival Models}
 \usage{
-\method{plot}{surv_shap}(x, ..., title = "SurvSHAP(t)", subtitle = "default", colors = NULL)
+\method{plot}{surv_shap}(
+  x,
+  ...,
+  title = "SurvSHAP(t)",
+  subtitle = "default",
+  max_vars = 7,
+  colors = NULL
+)
 }
 \arguments{
 \item{x}{an object of class \code{"surv_shap"} to be plotted}

--- a/man/predict_parts.surv_explainer.Rd
+++ b/man/predict_parts.surv_explainer.Rd
@@ -40,7 +40,7 @@ This function decomposes the model prediction into individual parts, which are a
 
 There are additional parameters that are passed to internal functions
 \itemize{
-\item for \code{surv_lime}
+\item for \code{survlime}
 \itemize{
 \item \code{N} -  a positive integer, number of observations generated in the neighbourhood
 \item \code{distance_metric} -  character, name of the distance metric to be used, only \code{"euclidean"} is implemented
@@ -51,7 +51,7 @@ There are additional parameters that are passed to internal functions
 \item \code{categorical_variables} -  character vector, names of variables that should be treated as categories (factors are included by default)
 \item \code{k} -  a small positive number > 1, added to chf before taking log, so that weigths aren't negative
 }
-\item for \code{surv_shap}
+\item for \code{survshap}
 \itemize{
 \item \code{timestamps} -  a numeric vector, time points at which the survival function will be evaluated
 \item \code{y_true} -  a two element numeric vector or matrix of one row and two columns, the first element being the true observed time and the second the status of the observation, used for plotting

--- a/man/predict_parts.surv_explainer.Rd
+++ b/man/predict_parts.surv_explainer.Rd
@@ -64,7 +64,7 @@ There are additional parameters that are passed to internal functions
 \section{References}{
 
 \itemize{
-\item [1] Krzyziński, Mateusz, et al. \href{https://arxiv.org/abs/2208.11080}{"SurvSHAP(t): Time-dependent explanations of machine learning survival models."} arXiv preprint arXiv:2208.11080 (2022).
+\item [1] Krzyziński, Mateusz, et al. \href{https://www.sciencedirect.com/science/article/pii/S0950705122013302}{"SurvSHAP(t): Time-dependent explanations of machine learning survival models."} Knowledge-Based Systems 262 (2023): 110234
 \item [2] Kovalev, Maxim S., et al. \href{https://www.sciencedirect.com/science/article/pii/S0950705120304044?casa_token=6e9cyk_ji3AAAAAA:tbqo33MsZvNC9nrSGabZdLfPtZTsvsvZTHYQCM2aEhumLI5D46U7ovhr37EaYUhmKZrw45JzDhg}{"SurvLIME: A method for explaining machine learning survival models."} Knowledge-Based Systems 203 (2020): 106164.
 }
 }

--- a/man/surv_shap.Rd
+++ b/man/surv_shap.Rd
@@ -44,7 +44,7 @@ Helper functions for \code{predict_parts.R}
 \section{References}{
 
 \itemize{
-\item [1] Krzyziński, Mateusz, et al. \href{https://arxiv.org/abs/2208.11080}{"SurvSHAP(t): Time-dependent explanations of machine learning survival models."} arXiv preprint arXiv:2208.11080 (2022).
+\item [1] Krzyziński, Mateusz, et al. \href{https://www.sciencedirect.com/science/article/pii/S0950705122013302}{"SurvSHAP(t): Time-dependent explanations of machine learning survival models."} Knowledge-Based Systems 262 (2023): 110234
 }
 }
 

--- a/vignettes/survex-usage.Rmd
+++ b/vignettes/survex-usage.Rmd
@@ -146,8 +146,7 @@ This type of plot also gives us valuable insight that is easy to overlook in the
 Another kind of functionality provided by this package is local explanations. The `predict_parts()` function can be used to assess the importance of variables while making predictions for a selected observation. This can be done by two methods, SurvSHAP(t) and SurvLIME.
 
 ### SurvSHAP(t)
-
-[SurvSHAP(t)](https://arxiv.org/abs/2208.11080) explanations are an extension of SHAP values for survival models. They show a breakdown of the prediction into individual variables.
+[SurvSHAP(t)](https://www.sciencedirect.com/science/article/pii/S0950705122013302) explanations are an extension of SHAP values for survival models. They show a breakdown of the prediction into individual variables.
 
 ```{r, include=FALSE}
 dev.off()


### PR DESCRIPTION
- Fixes for issues related to SurvSHAP(t) method: #27, #29, #30, #43, #44.
- Fixes for issues related to SurvLIME method: #46 
- In addition, for the sake of consistency, `plot_surv_lime` also have `max_vars` and issues with colors were resolved.

Additionally, it unifies the form of the results of both these explanations (except the class of the `variable_values` attribute - it will be fixed according to https://github.com/tagteam/riskRegression/issues/43). 

There are other fixes for consistency and compatibility:
- `max_vars` parameter is equal to 7 by default in all methods (a568a3999ec47ab3b6ff8e923711149072aeb216), 
-  added subtitle handling in `plot_feature_importance()` following other methods (e281ded0c195cc679c5dbb9384ee2f63f7abc29c).



