### PR TITLE
Added SurvSHAP(t) calculation with `kernelshap` package 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,6 +23,7 @@ Depends: R (>= 3.5.0)
 Imports:
     DALEX (>= 2.2.1),
     ggplot2,
+    kernelshap,
     pec,
     survival,
     patchwork

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # survex (development)
 
+* added new `calculation_method` for `surv_shap()` called `"kernelshap"` that use `kernelshap` package and its implementation of improved Kernel SHAP (set as default) ([#45](https://github.com/ModelOriented/survex/issues/45))
+* rename old method `"kernel"` to `"exact_kernel"`
+* added new import ([`kernelshap`](https://github.com/mayer79/kernelshap) package) 
 * *breaking change:* refactored the structure of `model_performance_survival` object - calculated metrics are now in a `$result` list.
 * fixed invalid color palette order in plot feature importance
 * fixed predict_parts survshap running out of memory with more than 16 variables ([#25](https://github.com/ModelOriented/survex/issues/25))

--- a/R/predict_parts.R
+++ b/R/predict_parts.R
@@ -28,7 +28,7 @@
 #' * for `survshap`
 #'     * `timestamps` -  a numeric vector, time points at which the survival function will be evaluated
 #'     * `y_true` -  a two element numeric vector or matrix of one row and two columns, the first element being the true observed time and the second the status of the observation, used for plotting
-#'     * `calculation_method` -  a character, only `"kernel"` is implemented for now.
+#'     * `calculation_method` -  a character, either `"kernelshap"` for use of `kernelshap` library (providing faster Kernel SHAP with refinements) or `"exact_kernel"` for exact Kernel SHAP estimation
 #'     * `aggregation_method` -  a character, either `"mean_absolute"` or `"integral"`, `"max_absolute"`, `"sum_of_squares"`
 #'
 #' @section References:

--- a/R/surv_shap.R
+++ b/R/surv_shap.R
@@ -45,7 +45,7 @@ surv_shap <- function(explainer,
     res$result <- switch(calculation_method,
                          "exact_kernel" = shap_kernel(explainer, new_observation, ...),
                          "kernelshap" = use_kernelshap(explainer, new_observation, ...),
-                         stop("Only calculations method `exact_kernel` and `kernelshap` are implemented"))
+                         stop("Only `exact_kernel` and `kernelshap` calculation methods are implemented"))
 
     if (!is.null(y_true)) res$y_true <- c(y_true_time = y_true_time, y_true_ind = y_true_ind)
 

--- a/R/surv_shap.R
+++ b/R/surv_shap.R
@@ -4,11 +4,8 @@
 #' @param new_observation a new observation for which predictions need to be explained
 #' @param ... additional parameters, passed to internal functions
 #' @param y_true a two element numeric vector or matrix of one row and two columns, the first element being the true observed time and the second the status of the observation, used for plotting
-#' @param calculation_method a character, only `"kernel"` is implemented for now.
+#' @param calculation_method a character, either `"kernelshap"` for use of `kernelshap` library (providing faster Kernel SHAP with refinements) or `"exact_kernel"` for exact Kernel SHAP estimation
 #' @param aggregation_method a character, either `"mean_absolute"` or `"integral"`, `"max_absolute"`, `"sum_of_squares"`
-#' @param path ignored, placeholder the not implemented `"sampling"` method
-#' @param B ignored, placeholder the not implemented `"sampling"` method
-#' @param exact ignored, placeholder the not implemented `"sampling"` method
 #'
 #' @return A list, containing the calculated SurvSHAP(t) results in the `result` field
 #'
@@ -21,7 +18,7 @@ surv_shap <- function(explainer,
                       ...,
                       y_true = NULL,
 
-                      calculation_method = "kernel",
+                      calculation_method = "kernelshap",
                       aggregation_method = "integral",
                       path = "average",
                       B = 25,
@@ -41,9 +38,14 @@ surv_shap <- function(explainer,
         }
     }
 
-    res <- switch(calculation_method,
-                  "kernel" = shap_kernel(explainer, new_observation, aggregation_method, ...),
-                  stop("Only calculation method = `kernel` is implemented"))
+    res <- list()
+    res$eval_times <- explainer$times
+    res$variable_values <- new_observation
+
+    res$result <- switch(calculation_method,
+                         "exact_kernel" = shap_kernel(explainer, new_observation, ...),
+                         "kernelshap" = use_kernelshap(explainer, new_observation, ...),
+                         stop("Only calculations method `exact_kernel` and `kernelshap` are implemented"))
 
     if (!is.null(y_true)) res$y_true <- c(y_true_time = y_true_time, y_true_ind = y_true_ind)
 
@@ -54,7 +56,7 @@ surv_shap <- function(explainer,
 }
 
 
-shap_kernel <- function(explainer, new_observation, aggregation_method,  ...) {
+shap_kernel <- function(explainer, new_observation, ...) {
 
     timestamps <- explainer$times
     p <- ncol(explainer$data)
@@ -71,13 +73,7 @@ shap_kernel <- function(explainer, new_observation, aggregation_method,  ...) {
 
     shap_values <- as.data.frame(shap_values, row.names = colnames(explainer$data))
     colnames(shap_values) <- paste("t=", timestamps, sep = "")
-
-    ret <- list()
-    ret$eval_times <- timestamps
-    ret$result <- data.frame(t(shap_values))
-    ret$variable_values <- new_observation
-
-    return(ret)
+    return (t(shap_values))
 }
 
 generate_shap_kernel_weights <- function(permutations, p) {
@@ -146,4 +142,20 @@ aggregate_surv_shap <- function(survshap, method) {
            })),
            stop("aggregation_method has to be one of `sum_of_squares`, `mean_absolute`, `max_absolute` or `integral`"))
 
+}
+
+
+use_kernelshap <- function(explainer, new_observation, ...){
+
+    predfun <- function(model, newdata){
+        explainer$predict_survival_function(model, newdata, times=explainer$times)
+    }
+
+    tmp_res <- kernelshap::kernelshap(explainer$model, new_observation, bg_X = explainer$data,
+               pred_fun = predfun, verbose=FALSE)
+
+    shap_values <- data.frame(t(sapply(tmp_res$S, cbind)))
+    colnames(shap_values) <- colnames(tmp_res$X)
+    rownames(shap_values) <- paste("t=", explainer$times, sep = "")
+    return(shap_values)
 }

--- a/man/predict_parts.surv_explainer.Rd
+++ b/man/predict_parts.surv_explainer.Rd
@@ -55,7 +55,7 @@ There are additional parameters that are passed to internal functions
 \itemize{
 \item \code{timestamps} -  a numeric vector, time points at which the survival function will be evaluated
 \item \code{y_true} -  a two element numeric vector or matrix of one row and two columns, the first element being the true observed time and the second the status of the observation, used for plotting
-\item \code{calculation_method} -  a character, only \code{"kernel"} is implemented for now.
+\item \code{calculation_method} -  a character, either \code{"kernelshap"} for use of \code{kernelshap} library (providing faster Kernel SHAP with refinements) or \code{"exact_kernel"} for exact Kernel SHAP estimation
 \item \code{aggregation_method} -  a character, either \code{"mean_absolute"} or \code{"integral"}, \code{"max_absolute"}, \code{"sum_of_squares"}
 }
 }

--- a/man/surv_shap.Rd
+++ b/man/surv_shap.Rd
@@ -9,7 +9,7 @@ surv_shap(
   new_observation,
   ...,
   y_true = NULL,
-  calculation_method = "kernel",
+  calculation_method = "kernelshap",
   aggregation_method = "integral",
   path = "average",
   B = 25,
@@ -25,15 +25,9 @@ surv_shap(
 
 \item{y_true}{a two element numeric vector or matrix of one row and two columns, the first element being the true observed time and the second the status of the observation, used for plotting}
 
-\item{calculation_method}{a character, only \code{"kernel"} is implemented for now.}
+\item{calculation_method}{a character, either \code{"kernelshap"} for use of \code{kernelshap} library (providing faster Kernel SHAP with refinements) or \code{"exact_kernel"} for exact Kernel SHAP estimation}
 
 \item{aggregation_method}{a character, either \code{"mean_absolute"} or \code{"integral"}, \code{"max_absolute"}, \code{"sum_of_squares"}}
-
-\item{path}{ignored, placeholder the not implemented \code{"sampling"} method}
-
-\item{B}{ignored, placeholder the not implemented \code{"sampling"} method}
-
-\item{exact}{ignored, placeholder the not implemented \code{"sampling"} method}
 }
 \value{
 A list, containing the calculated SurvSHAP(t) results in the \code{result} field


### PR DESCRIPTION
As in title - it addresses #45. 

- added new `calculation_method` for `surv_shap()` called `"kernelshap"` that use `kernelshap` package and its implementation of improved Kernel SHAP (set as default) 
- rename old method `"kernel"` to `"exact_kernel"`
- added new import ([`kernelshap`](https://github.com/mayer79/kernelshap) package) 
