### PR TITLE
Added possibility for plotting multiple local explanations for the same model (SurvSHAP(t))

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,7 @@
 * refactored integration of metrics ([#31](https://github.com/ModelOriented/survex/issues/31))
 * changed behaviour of `categorical_variables` argument in `model_parts()` and `predict_parts()`. If it contains variable names not present in the `variables` argument, they will be added at the end. ([#39](https://github.com/ModelOriented/survex/issues/39))
 * added ROC AUC calculation and plotting for selected timepoints in `model_performance()` ([#22](https://github.com/ModelOriented/survex/issues/22))
+* added `explanation_label` parameter to `predict_parts()` function that can overwrite explainer label and thus, enable plotting multiple local SurvSHAP(t) explanations. ([#47](https://github.com/ModelOriented/survex/issues/47))
 
 
 

--- a/R/predict_parts.R
+++ b/R/predict_parts.R
@@ -8,6 +8,7 @@
 #' @param N the maximum number of observations used for calculation of attributions. If `NULL` (default) all observations will be used.
 #' @param type if `output_type == "survival"` must be either `"survshap"` or `"survlime"`, otherwise refer to the `DALEX::predict_parts`
 #' @param output_type either `"survival"` or `"risk"` the type of survival model output that should be considered for explanations. If `"survival"` the explanations are based on the survival function. Otherwise the scalar risk predictions are used by the `DALEX::predict_parts` function.
+#' @param explanation_label a label that can overwrite explainer label (useful for multiple explanations for the same explainer/model)
 #'
 #' @return An object of class `"predict_parts_survival"` and additional classes depending on the type of explanations. It is a list with the element `result` containing the results of the calculation.
 #'
@@ -59,10 +60,8 @@ predict_parts <- function(explainer, ...) UseMethod("predict_parts", explainer)
 
 #' @rdname predict_parts.surv_explainer
 #' @export
-predict_parts.surv_explainer <- function(explainer, new_observation, ..., N = NULL, type = "survshap", output_type = "survival") {
-
-
-    label <- explainer$label
+predict_parts.surv_explainer <- function(explainer, new_observation, ..., N = NULL, type = "survshap", output_type = "survival",
+                                         explanation_label = NULL) {
 
     if (output_type == "risk") {
         return (DALEX::predict_parts(explainer = explainer,
@@ -80,7 +79,7 @@ predict_parts.surv_explainer <- function(explainer, new_observation, ..., N = NU
 
     }
 
-    attr(res, "label") <- label
+    attr(res, "label") <- ifelse(is.null(explanation_label), explainer$label, explanation_label)
     res$event_times <- explainer$y[,1]
     res$event_statuses <- explainer$y[,2]
     class(res) <- c('predict_parts_survival', class(res))

--- a/man/predict_parts.surv_explainer.Rd
+++ b/man/predict_parts.surv_explainer.Rd
@@ -13,7 +13,8 @@ predict_parts(explainer, ...)
   ...,
   N = NULL,
   type = "survshap",
-  output_type = "survival"
+  output_type = "survival",
+  explanation_label = NULL
 )
 }
 \arguments{
@@ -28,6 +29,8 @@ predict_parts(explainer, ...)
 \item{type}{if \code{output_type == "survival"} must be either \code{"survshap"} or \code{"survlime"}, otherwise refer to the \code{DALEX::predict_parts}}
 
 \item{output_type}{either \code{"survival"} or \code{"risk"} the type of survival model output that should be considered for explanations. If \code{"survival"} the explanations are based on the survival function. Otherwise the scalar risk predictions are used by the \code{DALEX::predict_parts} function.}
+
+\item{explanation_label}{a label that can overwrite explainer label (useful for multiple explanations for the same explainer/model)}
 }
 \value{
 An object of class \code{"predict_parts_survival"} and additional classes depending on the type of explanations. It is a list with the element \code{result} containing the results of the calculation.

--- a/tests/testthat/test-predict_parts.R
+++ b/tests/testthat/test-predict_parts.R
@@ -23,6 +23,9 @@ test_that("survshap explanations work", {
 
     plot(parts_cph, parts_ranger, parts_src)
 
+    parts_cph2 <- predict_parts(cph_exp, veteran[4,], explanation_label = "second_explanation")
+    plot(parts_cph, parts_cph2)
+
     expect_s3_class(parts_cph, c("predict_parts_survival", "surv_shap"))
     expect_s3_class(parts_ranger, c("predict_parts_survival", "surv_shap"))
     expect_s3_class(parts_src, c("predict_parts_survival", "surv_shap"))


### PR DESCRIPTION
Closes #47 by adding `explanation_label` parameter to `predict_parts()` function that can overwrite explainer label and thus, enable plotting multiple local SurvSHAP(t) explanations.